### PR TITLE
Add phantom digest support to download

### DIFF
--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -18,9 +18,11 @@ clap = { version = "3.2.17", features = ["derive"] }
 compact_str = { version = "0.5.2", features = ["serde"] }
 crates_io_api = { version = "0.8.0", default-features = false }
 detect-targets = { version = "0.1.0", path = "../detect-targets" }
+digest = "0.10.3"
 flate2 = { version = "1.0.24", default-features = false }
 flock = { version = "0.1.0", path = "../flock" }
 futures-util = { version = "0.3.23", default-features = false }
+generic-array = "0.14.6"
 home = "0.5.3"
 itertools = "0.10.3"
 jobserver = "0.1.24"

--- a/crates/lib/src/drivers/crates_io.rs
+++ b/crates/lib/src/drivers/crates_io.rs
@@ -9,7 +9,7 @@ use url::Url;
 
 use crate::{
     errors::BinstallError,
-    helpers::download::download_tar_based_and_visit,
+    helpers::download::Download,
     manifests::cargo_toml_binstall::{Meta, TarBasedFmt},
 };
 
@@ -52,9 +52,7 @@ pub async fn fetch_crate_cratesio(
 
     let manifest_dir_path: PathBuf = format!("{name}-{version_name}").into();
 
-    download_tar_based_and_visit(
-        client,
-        Url::parse(&crate_url)?,
+    Download::new(client, Url::parse(&crate_url)?).and_visit_tar(
         TarBasedFmt::Tgz,
         ManifestVisitor::new(manifest_dir_path),
     )

--- a/crates/lib/src/fetchers/gh_crate_meta.rs
+++ b/crates/lib/src/fetchers/gh_crate_meta.rs
@@ -10,7 +10,7 @@ use url::Url;
 
 use crate::{
     errors::BinstallError,
-    helpers::{download::download_and_extract, remote::remote_exists, tasks::AutoAbortJoinHandle},
+    helpers::{download::Download, remote::remote_exists, tasks::AutoAbortJoinHandle},
     manifests::cargo_toml_binstall::PkgFmt,
 };
 
@@ -75,7 +75,7 @@ impl super::Fetcher for GhCrateMeta {
     async fn fetch_and_extract(&self, dst: &Path) -> Result<(), BinstallError> {
         let url = self.url.get().unwrap(); // find() is called first
         debug!("Downloading package from: '{url}'");
-        download_and_extract(&self.client, url, self.pkg_fmt(), dst).await
+        Download::new(&self.client, url.clone()).and_extract(self.pkg_fmt(), dst).await
     }
 
     fn pkg_fmt(&self) -> PkgFmt {

--- a/crates/lib/src/fetchers/quickinstall.rs
+++ b/crates/lib/src/fetchers/quickinstall.rs
@@ -9,7 +9,7 @@ use url::Url;
 
 use crate::{
     errors::BinstallError,
-    helpers::{download::download_and_extract, remote::remote_exists},
+    helpers::{download::Download, remote::remote_exists},
     manifests::cargo_toml_binstall::PkgFmt,
 };
 
@@ -47,7 +47,7 @@ impl super::Fetcher for QuickInstall {
     async fn fetch_and_extract(&self, dst: &Path) -> Result<(), BinstallError> {
         let url = self.package_url();
         debug!("Downloading package from: '{url}'");
-        download_and_extract(&self.client, &Url::parse(&url)?, self.pkg_fmt(), dst).await
+        Download::new(&self.client, Url::parse(&url)?).and_extract(self.pkg_fmt(), dst).await
     }
 
     fn pkg_fmt(&self) -> PkgFmt {

--- a/crates/lib/src/helpers/download.rs
+++ b/crates/lib/src/helpers/download.rs
@@ -1,5 +1,6 @@
-use std::{fmt::Debug, path::Path};
+use std::{fmt::Debug, path::Path, marker::PhantomData};
 
+use digest::{Digest, FixedOutput, Output, Update, HashMarker, OutputSizeUser};
 use log::debug;
 use reqwest::{Client, Url};
 
@@ -17,47 +18,83 @@ pub use async_extracter::TarEntriesVisitor;
 mod async_extracter;
 mod extracter;
 mod stream_readable;
-/// Download a file from the provided URL and extract it to the provided path.
-pub async fn download_and_extract<P: AsRef<Path>>(
-    client: &Client,
-    url: &Url,
-    fmt: PkgFmt,
-    path: P,
-) -> Result<(), BinstallError> {
-    let stream = create_request(client, url.clone()).await?;
 
-    let path = path.as_ref();
-    debug!("Downloading and extracting to: '{}'", path.display());
+#[derive(Debug)]
+pub struct Download<'client, D: Digest = NoDigest> {
+    client: &'client Client,
+    url: Url,
+    _digest: PhantomData<D>,
+    _checksum: Vec<u8>,
+}
 
-    match fmt.decompose() {
-        PkgFmtDecomposed::Tar(fmt) => extract_tar_based_stream(stream, path, fmt).await?,
-        PkgFmtDecomposed::Bin => extract_bin(stream, path).await?,
-        PkgFmtDecomposed::Zip => extract_zip(stream, path).await?,
+impl<'client> Download<'client> {
+    pub fn new(client: &'client Client, url: Url) -> Self {
+        Self { client, url, _digest: PhantomData::default(), _checksum: Vec::new() }
+    }
+}
+
+impl<'client, D: Digest> Download<'client, D> {
+    pub fn new_with_checksum(client: &'client Client, url: Url, checksum: Vec<u8>) -> Self {
+        Self { client, url, _digest: PhantomData::default(), _checksum: checksum }
     }
 
-    debug!("Download OK, extracted to: '{}'", path.display());
+    /// Download a file from the provided URL and extract it to the provided path.
+    pub async fn and_extract(
+        self,
+        fmt: PkgFmt,
+        path: impl AsRef<Path>,
+    ) -> Result<(), BinstallError> {
+        let stream = create_request(self.client, self.url).await?;
 
-    Ok(())
+        let path = path.as_ref();
+        debug!("Downloading and extracting to: '{}'", path.display());
+
+        match fmt.decompose() {
+            PkgFmtDecomposed::Tar(fmt) => extract_tar_based_stream(stream, path, fmt).await?,
+            PkgFmtDecomposed::Bin => extract_bin(stream, path).await?,
+            PkgFmtDecomposed::Zip => extract_zip(stream, path).await?,
+        }
+
+        debug!("Download OK, extracted to: '{}'", path.display());
+
+        Ok(())
+    }
+
+    /// Download a file from the provided URL and extract part of it to
+    /// the provided path.
+    ///
+    ///  * `filter` - If Some, then it will pass the path of the file to it
+    ///    and only extract ones which filter returns `true`.
+    pub async fn and_visit_tar<V: TarEntriesVisitor + Debug + Send + 'static>(
+        self,
+        fmt: TarBasedFmt,
+        visitor: V,
+    ) -> Result<V::Target, BinstallError> {
+        let stream = create_request(self.client, self.url).await?;
+
+        debug!("Downloading and extracting then in-memory processing");
+
+        let ret = extract_tar_based_stream_and_visit(stream, fmt, visitor).await?;
+
+        debug!("Download, extraction and in-memory procession OK");
+
+        Ok(ret)
+    }
 }
 
-/// Download a file from the provided URL and extract part of it to
-/// the provided path.
-///
-///  * `filter` - If Some, then it will pass the path of the file to it
-///    and only extract ones which filter returns `true`.
-pub async fn download_tar_based_and_visit<V: TarEntriesVisitor + Debug + Send + 'static>(
-    client: &Client,
-    url: Url,
-    fmt: TarBasedFmt,
-    visitor: V,
-) -> Result<V::Target, BinstallError> {
-    let stream = create_request(client, url).await?;
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NoDigest;
 
-    debug!("Downloading and extracting then in-memory processing");
-
-    let ret = extract_tar_based_stream_and_visit(stream, fmt, visitor).await?;
-
-    debug!("Download, extraction and in-memory procession OK");
-
-    Ok(ret)
+impl FixedOutput for NoDigest {
+    fn finalize_into(self, _out: &mut Output<Self>) {}
 }
+
+impl OutputSizeUser for NoDigest {
+    type OutputSize = generic_array::typenum::U0;
+}
+
+impl Update for NoDigest {
+    fn update(&mut self, _data: &[u8]) {}
+}
+
+impl HashMarker for NoDigest {}


### PR DESCRIPTION
I'm not entirely sure how to actually implement this, but that's a convenient API for it. Notably it's generic over the kind of digest, and defaults to a noop digest.